### PR TITLE
Fix our publishing scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "avatars-utils",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc",
     "test": "TS_NODE_FILES=true jasmine-ts --config=./jasmine.json",
-    "prePublishOnly": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "avatars",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Utilities for the Adorable Avatars service",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avatars-utils",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Utilities for the Adorable Avatars service",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Turns out `prepublishOnly` is case sensitive. Whoops!

This adds types to the manifest, and publishes 0.0.2 with real contents!