### PR TITLE
Remove global declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,0 @@
-type ReducerFn = (array: number[]) => number;
-type HashFn = (key: string) => number;

--- a/src/Hash/Hash.ts
+++ b/src/Hash/Hash.ts
@@ -1,4 +1,4 @@
-import { sumHash } from './hashing';
+import { sumHash, HashFn } from './hashing';
 
 export class Hash<T> {
   public length: number;

--- a/src/Hash/hashing.ts
+++ b/src/Hash/hashing.ts
@@ -1,5 +1,4 @@
-import { sum } from '../math';
-import { ReducerFn } from '../math/reducers';
+import { sum, ReducerFn } from '../math';
 
 export type HashFn = (key: string) => number;
 

--- a/src/Hash/hashing.ts
+++ b/src/Hash/hashing.ts
@@ -1,4 +1,7 @@
 import { sum } from '../math';
+import { ReducerFn } from '../math/reducers';
+
+export type HashFn = (key: string) => number;
 
 const getCharInt = (char: string): number => Number(char.charCodeAt(0)) || 0;
 

--- a/src/Hash/index.ts
+++ b/src/Hash/index.ts
@@ -1,2 +1,2 @@
-export { hashFactory, sumHash } from './hashing';
+export { hashFactory, sumHash, HashFn } from './hashing';
 export { Hash } from './Hash';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { product, sum, sumAndDiff } from './math';
+export { product, sum, sumAndDiff, ReducerFn } from './math';
 export { filePaths, fileNames } from './fs';
-export { Hash, sumHash } from './Hash';
+export { Hash, HashFn, hashFactory, sumHash } from './Hash';

--- a/src/math/index.ts
+++ b/src/math/index.ts
@@ -1,1 +1,1 @@
-export { product, sum, sumAndDiff } from './reducers';
+export { product, sum, sumAndDiff, ReducerFn } from './reducers';

--- a/src/math/reducers.ts
+++ b/src/math/reducers.ts
@@ -1,3 +1,5 @@
+export type ReducerFn = (array: number[]) => number;
+
 const isEven: (num: number) => boolean = num => num % 2 === 0;
 
 export const sum: ReducerFn = arr => arr.reduce((a, b) => a + b, 0);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,6 @@
     "moduleResolution": "node",
     "outDir": "dist"
   },
-  "include": ["src/**/*", "index.d.ts"],
+  "include": ["src/**/*"],
   "exclude": ["src/**/*.test.*"]
 }


### PR DESCRIPTION
Because those aren't exported to a declaration file. Instead, use these
types in our code as we need them, and typescript will do the right
thing.